### PR TITLE
Bigger multicalls; more server/download/file calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/cemeyer/rtorrent-xmlrpc-bindings"
 categories = ["api-bindings"]
 keywords = ["rtorrent", "xmlrpc", "rpc", "remote", "control"]
 license = "MIT"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/download.rs
+++ b/src/download.rs
@@ -229,6 +229,24 @@ impl Download {
     d_bool_getter!(is_active);
     d_bool_getter!(is_open);
     d_bool_getter!(is_closed);
+    
+    d_bool_getter!(
+        /// starts torrent
+        start);
+    d_bool_getter!(
+        /// stops torrent
+        stop);
+    
+    d_bool_getter!(
+        /// removes torrent from rtorrent's index of torrents/stops seeding/downloading (DOES NOT REMOVE DATA the data the torrent is downloading from disk- only the metafile)
+        erase);
+    
+    d_bool_getter!(
+        /// starts rtorrent on process of checking torrent against the hash
+        check_hash);
+    d_bool_getter!(
+        /// rtorrent will refresh tracker about its own status and potentially get information about new peers
+        tracker_announce);
 
     d_str_getter!(
         /// The metafile from which this download was created.
@@ -242,7 +260,10 @@ impl Download {
     d_str_getter!(
         /// Get the name of the torrent.
         name);
-
+    d_str_getter!(
+        /// Get the bitfield of the torrent.
+        bitfield
+    );
     d_f1000_getter!(
         /// Get the upload/download ratio for this download.
         ratio);
@@ -251,8 +272,13 @@ impl Download {
         /// Get the size, in bytes, of the torrent contents.
         size_bytes);
     d_int_getter!(
+        /// Get the bytes left to verify and/or download.
+        left_bytes
+    );
+    d_int_getter!(
         /// Get the number of files associated with this download.
         size_files);
+
     d_bool_getter!(
         /// Get the state (`false` is stopped).
         state);

--- a/src/download.rs
+++ b/src/download.rs
@@ -46,10 +46,19 @@ macro_rules! d_int_getter_named {
         prim_getter_named!($(#[$meta])* "d.", $method, i64, $apimethod);
     }
 }
-
+macro_rules! d_str_getter_named {
+    ($(#[$meta:meta])* $method: ident, $apimethod: literal) => {
+        prim_getter_named!($(#[$meta])* "d.", $method, String, $apimethod);
+    }
+}
 macro_rules! d_str_setter {
     ($(#[$meta:meta])* $rmethod: ident, $apimethod: ident) => {
         prim_setter!($(#[$meta])* "d.", $rmethod, $apimethod, &str);
+    }
+}
+macro_rules! d_int_setter {
+    ($(#[$meta:meta])* $rmethod: ident, $apimethod: ident) => {
+        prim_setter!($(#[$meta])* "d.", $rmethod, $apimethod, i64);
     }
 }
 
@@ -231,21 +240,21 @@ impl Download {
     d_bool_getter!(is_closed);
     
     d_bool_getter!(
-        /// starts torrent
+        /// Starts torrent
         start);
     d_bool_getter!(
-        /// stops torrent
+        /// Stops torrent
         stop);
     
     d_bool_getter!(
-        /// removes torrent from rtorrent's index of torrents/stops seeding/downloading (DOES NOT REMOVE DATA the data the torrent is downloading from disk- only the metafile)
+        /// Removes torrent from rtorrent's index of torrents, removes only the metafile if configured on rtorrent.
         erase);
     
     d_bool_getter!(
-        /// starts rtorrent on process of checking torrent against the hash
+        /// Checking torrent against the hash.
         check_hash);
     d_bool_getter!(
-        /// rtorrent will refresh tracker about its own status and potentially get information about new peers
+        /// Re-announce tracker about its own status and potentially get information about new peers.
         tracker_announce);
 
     d_str_getter!(
@@ -267,7 +276,8 @@ impl Download {
     d_f1000_getter!(
         /// Get the upload/download ratio for this download.
         ratio);
-
+    d_int_setter!(
+        priority_set, priority);
     d_int_getter!(
         /// Get the size, in bytes, of the torrent contents.
         size_bytes);
@@ -297,6 +307,16 @@ impl Download {
     d_int_getter_named!(
         /// Get the upload total (bytes).
         up_total, "up.total");
+    d_str_getter_named!(
+        /// Get the group of  torrent.
+        group_name, "group.name");
+    d_int_getter!(
+        // Get creation date of torrent.
+        creation_date);
+    d_int_getter!(
+        // Get date torrent was loaded.
+        load_date);
+
 }
 
 unsafe impl Send for Download {}

--- a/src/file.rs
+++ b/src/file.rs
@@ -83,6 +83,9 @@ pub struct File {
 }
 
 impl File {
+    pub fn from_id(download: Download, index: i64) -> Self {
+        Self { inner: Arc::new(FileInner { download, index, }) }
+    }
     pub(crate) fn new(download: Download, index: i64) -> Self {
         Self { inner: Arc::new(FileInner { download, index, }) }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,22 +148,23 @@ impl Server {
     pub fn new(endpoint: &str) -> Self {
         Self { inner: Arc::new(ServerInner { endpoint: endpoint.to_owned() }) }
     }
-
+    pub fn get_endpoint(&self) -> String {
+        self.inner.endpoint.clone()
+    }
     #[inline]
     fn endpoint(&self) -> &str {
         &self.inner.endpoint
     }
-    /// this directs rtorrent to open a shell and remove some file - not yet operational.
-    pub fn delete_path_exec(&self, path: String) -> Result<String> {
-        let raw_response = Request::new("execute.capture")
+
+    /// Rrtorrent to open a shell and remove path.
+    pub fn delete_path_exec(&self, path: String) -> Result<i64> {
+        let raw_response = Request::new("execute.throw.bg")
             .arg("")
             .arg("sh")
             .arg("-c")
-            .arg("rm")
-            .arg("-vrf")
-            .arg(format!("{}", path))
+            .arg(format!("rm -vrf {}",path))
             .call_url(self.endpoint())?;
-        <String as TryFromValue>::try_from_value(&raw_response)
+        <i64 as TryFromValue>::try_from_value(&raw_response)
     }
     /// Get a list of all downloads loaded in this instance of rtorrent.
     pub fn download_list(&self) -> Result<Vec<Download>> {
@@ -173,9 +174,33 @@ impl Server {
             .map(|v| Download::from_value(&self, v))
             .collect()
     }
-    /// Add torrent from url/magnetlink - will start upon adding
-        pub fn add_tor_started_exec(&self, tor: String) -> Result<i64> {
+    /// Add torrent from url/magnetlink - will start upon adding.
+    pub fn add_tor_started(&self, tor: String) -> Result<i64> {
         let raw_response = Request::new("load.start_verbose")
+            .arg("")
+            .arg(tor)
+            .call_url(self.endpoint())?;
+        <i64 as TryFromValue>::try_from_value(&raw_response)
+    }
+    /// Add torrent from url/magnetlink - will not start upon adding
+    pub fn add_tor_paused(&self, tor: String) -> Result<i64> {
+        let raw_response = Request::new("load.verbose")
+            .arg("")
+            .arg(tor)
+            .call_url(self.endpoint())?;
+        <i64 as TryFromValue>::try_from_value(&raw_response)
+    }
+    /// Takes a vec of bytes of a torrent/metafile and passes that to rtorrent to be added, but not started.
+    pub fn add_tor_from_vec_u8_paused(&self, tor: Vec<u8>) -> Result<i64> {
+        let raw_response = Request::new("load.raw_verbose")
+            .arg("")
+            .arg(tor)
+            .call_url(self.endpoint())?;
+        <i64 as TryFromValue>::try_from_value(&raw_response)
+    }
+    /// Takes a vec of bytes of a torrent/metafile and passes that to rtorrent to be added & started.
+    pub fn add_tor_from_vec_u8_started(&self, tor: Vec<u8>) -> Result<i64> {
+        let raw_response = Request::new("load.raw_start_verbose")
             .arg("")
             .arg(tor)
             .call_url(self.endpoint())?;
@@ -185,8 +210,14 @@ impl Server {
         /// Get the IP address associated with this rtorrent instance.
         ip, "network.bind_address", String);
     server_getter!(
+        /// Get the port(s) associated with this rtorrent instance.
+        port, "network.port_range", String);
+    server_getter!(
         /// Get the hostname associated with this rtorrent instance.
         hostname, "system.hostname", String);
+    server_getter!(
+        /// Get the time in seconds since Unix Epoch when this rtorrent instance was started.
+        startup_time, "system.startup_time", i64);
     server_getter!(
         /// Exit rtorrent, does not force any connections down, not just the rtorrent xmlrpc server 
         exit_rtorrent, "system.shutdown.normal", i64

--- a/src/multicall/mod.rs
+++ b/src/multicall/mod.rs
@@ -31,7 +31,7 @@ mod raw {
     raw_impl::define_builder!(MultiBuilder1, MultiBuilder2, phantom_a A | phantom_b B);
     raw_impl::define_builder!(MultiBuilder2, MultiBuilder3, phantom_a A, phantom_b B | phantom_c C);
     raw_impl::define_builder!(MultiBuilder3, MultiBuilder4, phantom_a A, phantom_b B, phantom_c C | phantom_d D);
-        raw_impl::define_builder!(MultiBuilder4, MultiBuilder5, phantom_a A, phantom_b B, phantom_c C , phantom_d D | phantom_e E);
+    raw_impl::define_builder!(MultiBuilder4, MultiBuilder5, phantom_a A, phantom_b B, phantom_c C , phantom_d D | phantom_e E);
     raw_impl::define_builder!(MultiBuilder5, MultiBuilder6, phantom_a A, phantom_b B, phantom_c C , phantom_d D , phantom_e E | phantom_g G);
     raw_impl::define_builder!(MultiBuilder6, MultiBuilder7, phantom_a A, phantom_b B, phantom_c C , phantom_d D , phantom_e E, phantom_g G | phantom_h H);
     raw_impl::define_builder!(MultiBuilder7, MultiBuilder8, phantom_a A, phantom_b B, phantom_c C , phantom_d D , phantom_e E, phantom_g G , phantom_h H | phantom_i I);
@@ -82,7 +82,7 @@ pub mod d {
     define_builder!(
         /// `MultiBuilder4` represents a four-column query over all `Download`s in a view
         MultiBuilder3, MultiBuilder4, phantom_a A, phantom_b B, phantom_c C | phantom_d D);
-        define_builder!(
+    define_builder!(
         /// `MultiBuilder5` represents a four-column query over all `Download`s in a view
         MultiBuilder4, MultiBuilder5, phantom_a A, phantom_b B, phantom_c C , phantom_d D | phantom_e E);
     define_builder!(

--- a/src/multicall/mod.rs
+++ b/src/multicall/mod.rs
@@ -31,6 +31,11 @@ mod raw {
     raw_impl::define_builder!(MultiBuilder1, MultiBuilder2, phantom_a A | phantom_b B);
     raw_impl::define_builder!(MultiBuilder2, MultiBuilder3, phantom_a A, phantom_b B | phantom_c C);
     raw_impl::define_builder!(MultiBuilder3, MultiBuilder4, phantom_a A, phantom_b B, phantom_c C | phantom_d D);
+        raw_impl::define_builder!(MultiBuilder4, MultiBuilder5, phantom_a A, phantom_b B, phantom_c C , phantom_d D | phantom_e E);
+    raw_impl::define_builder!(MultiBuilder5, MultiBuilder6, phantom_a A, phantom_b B, phantom_c C , phantom_d D , phantom_e E | phantom_g G);
+    raw_impl::define_builder!(MultiBuilder6, MultiBuilder7, phantom_a A, phantom_b B, phantom_c C , phantom_d D , phantom_e E, phantom_g G | phantom_h H);
+    raw_impl::define_builder!(MultiBuilder7, MultiBuilder8, phantom_a A, phantom_b B, phantom_c C , phantom_d D , phantom_e E, phantom_g G , phantom_h H | phantom_i I);
+    raw_impl::define_builder!(MultiBuilder8, MultiBuilder9, phantom_a A, phantom_b B, phantom_c C , phantom_d D , phantom_e E, phantom_g G , phantom_h H , phantom_i I | phantom_j J);
 }
 
 /// The `d` module builds multicalls over `Download`s
@@ -77,6 +82,21 @@ pub mod d {
     define_builder!(
         /// `MultiBuilder4` represents a four-column query over all `Download`s in a view
         MultiBuilder3, MultiBuilder4, phantom_a A, phantom_b B, phantom_c C | phantom_d D);
+        define_builder!(
+        /// `MultiBuilder5` represents a four-column query over all `Download`s in a view
+        MultiBuilder4, MultiBuilder5, phantom_a A, phantom_b B, phantom_c C , phantom_d D | phantom_e E);
+    define_builder!(
+        /// `MultiBuilder6` represents a four-column query over all `Download`s in a view
+        MultiBuilder5, MultiBuilder6, phantom_a A, phantom_b B, phantom_c C , phantom_d D, phantom_e E | phantom_g G);
+    define_builder!(
+        /// `MultiBuilder7` represents a four-column query over all `Download`s in a view
+        MultiBuilder6, MultiBuilder7, phantom_a A, phantom_b B, phantom_c C , phantom_d D, phantom_e E, phantom_g G | phantom_h H);
+    define_builder!(
+        /// `MultiBuilder8` represents a four-column query over all `Download`s in a view
+        MultiBuilder7, MultiBuilder8, phantom_a A, phantom_b B, phantom_c C , phantom_d D, phantom_e E, phantom_g G , phantom_h H | phantom_i I);
+    define_builder!(
+        /// `MultiBuilder9` represents a four-column query over all `Download`s in a view
+        MultiBuilder8, MultiBuilder9, phantom_a A, phantom_b B, phantom_c C , phantom_d D, phantom_e E, phantom_g G , phantom_h H , phantom_i I | phantom_j J);
 }
 
 /// The `f` module builds multicalls over `File`s in a `Download`
@@ -123,6 +143,9 @@ pub mod f {
     define_builder!(
         /// `MultiBuilder4` represents a four-column query over all `File`s in a `Download`
         MultiBuilder3, MultiBuilder4, phantom_a A, phantom_b B, phantom_c C | phantom_d D);
+    define_builder!(
+        /// `MultiBuilder5` represents a four-column query over all `File`s in a `Download`
+        MultiBuilder4, MultiBuilder5, phantom_a A, phantom_b B, phantom_c C , phantom_d D | phantom_e E);
 }
 
 /// The `p` module builds multicalls over `Peer`s on a `Download`
@@ -176,6 +199,15 @@ pub mod p {
         /// `MultiBuilder4` represents a four-column query over all swarm `Peers` associated with a
         /// `Download`
         MultiBuilder3, MultiBuilder4, phantom_a A, phantom_b B, phantom_c C | phantom_d D);
+    define_builder!(
+        /// `MultiBuilder5` represents a four-column query over all swarm `Peers` associated with a
+        /// `Download`
+        MultiBuilder4, MultiBuilder5, phantom_a A, phantom_b B, phantom_c C , phantom_d D | phantom_e E);
+    define_builder!(
+        /// `MultiBuilder6` represents a four-column query over all swarm `Peers` associated with a
+        /// `Download`
+        MultiBuilder5, MultiBuilder6, phantom_a A, phantom_b B, phantom_c C , phantom_d D, phantom_e E | phantom_f F);
+
 }
 
 /// The `t` module builds multicalls over `Trackers`s associated with a `Download`

--- a/src/multicall/ops/d.rs
+++ b/src/multicall/ops/d.rs
@@ -101,6 +101,10 @@ d_op_const!(
     /// The number of completed bytes.
     COMPLETED_BYTES, i64, "completed_bytes");
 d_op_const!(
+    //for left bytes
+    LEFT_BYTES, i64, "left_bytes"
+);
+d_op_const!(
     /// The number of completed chunks (pieces).
     COMPLETED_CHUNKS, i64, "completed_chunks");
 d_op_const!(
@@ -112,6 +116,10 @@ d_op_const!(
 d_op_const!(
     /// Is this torrent active?
     IS_ACTIVE, bool, "is_active");
+d_op_const!(
+    //is thist torrent hashing?
+    IS_HASH_CHECKING, bool, "is_hash_checking"
+);
 d_op_const!(
     IS_OPEN, bool, "is_open");
 d_op_const!(

--- a/src/multicall/ops/t.rs
+++ b/src/multicall/ops/t.rs
@@ -76,3 +76,22 @@ macro_rules! t_op_const {
 t_op_const!(
     /// Get the URL of the tracker.
     URL, String, "url");
+
+t_op_const!(
+    // Get the last time rtorrent attempted to contact tracker.
+    ACTIVTY_TIME_LAST, i64, "activity_time_last");
+
+t_op_const!(
+    // Get the next time rtorrent will attempt to contact tracker.
+    ACTIVTY_TIME_NEXT, i64, "activity_time_next");
+    
+t_op_const!(
+    // Get the next time rtorrent will attempt to contact tracker.
+    GROUP, i64, "group");
+t_op_const!(
+    // Get the tracker ID.
+    ID, String, "id");
+
+t_op_const!(
+    // Get the number of peers the tracker returned last scrape.
+    LATEST_SUM_PEERS, i64, "latest_sum_peers");


### PR DESCRIPTION
Thanks for making such a great library - I thought about making an rtorrent CLI-ui and had been kind of slogging through xmlrpc-rs myself and so your library was a great help. **I am currently probably a couple days away from a viable alpha on it and would like to know if you would like me to fork your repo or  would you like to incorporate my code?** Either way is fine by me.

This is currently feature complete to where I am now, but I will need a couple more things, I am going to need to do load_raw_start to add .torrent directly to rtorrent; as well as load_torrent_paused and load_raw for paused. The biggest thing yet to add is I need to send a rather complicated call to capture the .base_filename(), remove the torrent from rtorrent and then delete the path of .base_filename() - but it shouldn't be too hard.